### PR TITLE
Use the sprawlnet message format in SprawlClient

### DIFF
--- a/SprawlClient/SprawlNet.cpp
+++ b/SprawlClient/SprawlNet.cpp
@@ -6,6 +6,8 @@
 //  Copyright 2011 Kosepeisen. All rights reserved.
 //
 
+#include <string.h>
+
 #include "SprawlNet.h"
 
 SprawlNet::SprawlNet( const std::string &Host, const std::string &Port )

--- a/SprawlClient/main.cpp
+++ b/SprawlClient/main.cpp
@@ -6,18 +6,40 @@
 //  Copyright 2011 Kosepeisen. All rights reserved.
 //
 
+#include <string.h>
+
 #include <iostream>
 
 #include "SprawlNet.h"
+
+void CreateMessage(std::string Content, char **MessageDest,
+        size_t *LengthDest) {
+    *LengthDest = Content.length() + sizeof(int);
+    *MessageDest = new char[Content.length() + sizeof(int)];
+    int MessageLength = Content.length();
+    memcpy(*MessageDest, &MessageLength, sizeof(int));
+    memcpy(*MessageDest + sizeof(int), Content.c_str(), Content.length());
+}
+
+void SendMessage(const SprawlNet *Network, std::string Message) {
+    char *MessageBuffer;
+    size_t Length;
+
+    CreateMessage(Message, &MessageBuffer, &Length);
+    Network->SendData( MessageBuffer, Length );
+    delete MessageBuffer;
+}
 
 int main (int argc, const char * argv[])
 {
     SprawlNet *Network = new SprawlNet( "127.0.0.1", "1337");
     
-    std::string test("lalal1337");
-    
-    if( Network->IsConnected() )
-        Network->SendData( test.c_str(), test.length() );
+    if( Network->IsConnected() ) {
+        SendMessage(Network, "lalalal1337");
+        SendMessage(Network, "SprawlNet loading...");
+        SendMessage(Network, "SprawlNet loading....");
+        SendMessage(Network, "SprawlNet loading.....");
+    }
     
     delete Network;
 


### PR DESCRIPTION
SprawlClient was merged into sprawlnet with a subtree merge. Therefore the sprawlnet history comes along if you merge this. Also, this message format makes it harder to debug the client with e.g. nc, because the messages are binary data.

Check out https://github.com/orbekk/sprawlnet/tree/SprawlClient-merge for the current progress. Usage, something like:

git clone git://github.com/orbekk/sprawlnet.git
cd sprawlnet
git checkout SprawlClient-merge
make
(cd client/SprawlClient; make)
./main &
./client/SprawlClient.bin

Kjetil.
